### PR TITLE
Podcast show api update

### DIFF
--- a/app/facades/podcast_facade.rb
+++ b/app/facades/podcast_facade.rb
@@ -16,8 +16,8 @@ class PodcastFacade
   end
 
   def episodes
-    formatted_episodes = Episode.make_episodes(@podcast.spotify_uri) 
-    formatted_episodes.map do |episode_hash|
+    formatted_episodes = Episode.make_episodes(@podcast.spotify_uri)
+    x =formatted_episodes.map do |episode_hash|
       Episode.new(episode_hash)
     end
   end

--- a/app/facades/podcast_facade.rb
+++ b/app/facades/podcast_facade.rb
@@ -17,7 +17,7 @@ class PodcastFacade
 
   def episodes
     formatted_episodes = Episode.make_episodes(@podcast.spotify_uri)
-    x =formatted_episodes.map do |episode_hash|
+    formatted_episodes.map do |episode_hash|
       Episode.new(episode_hash)
     end
   end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,28 +1,31 @@
 class Episode
-  attr_reader :name, :description, :audio
+  attr_reader :title, :description, :audio, :audio_length_sec, :pub_date
 
   def initialize(formatted_episodes)
-    @name = formatted_episodes[:name]
+    @title = formatted_episodes[:title]
     @description = formatted_episodes[:description]
     @audio = formatted_episodes[:audio]
+    @audio_length_sec = formatted_episodes[:audio_length_sec]
+    @pub_date = formatted_episodes[:pub_date]
   end
 
   def self.make_episodes(spotify_uri)
       podcast_service = PodcastService.new
-      episode_details = podcast_service.episodes(spotify_uri)
-      format_episode_details(episode_details)
+      podcast_details = podcast_service.podcast(spotify_uri)
+      format_episode_details(podcast_details[:data][:episodes])
   end
 
 
   private
   def self.format_episode_details(episode_details)
-    episode_details[:episodes][:items][0..4].map do |details|
+    episode_details.map do |details|
       {
-        :name => details[:name],
+        :title => details[:title],
         :description => details[:description],
-        :audio => details[:audio_preview_url]
+        :audio => details[:audio],
+        :audio_length_sec => details[:audio_length_sec],
+        :pub_date => details[:pub_date]
       }
     end
-
   end
 end

--- a/app/services/podcast_service.rb
+++ b/app/services/podcast_service.rb
@@ -1,12 +1,16 @@
 class PodcastService
-  def episodes(spotify_uri)
-    get_json("spec/fixtures/armchair.json")
+  def podcast(podcast_id)
+    get_json("/podcast/#{podcast_id}")
   end
 
 private
 
-  def get_json(filename)
-    file_content = File.read(filename)
-    JSON.parse(file_content, symbolize_names: true)
+  def conn
+    Faraday.new(url: 'https://podsmack-microservice.herokuapp.com')
+  end
+
+  def get_json(uri)
+    response = conn.get(uri)
+    JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -17,10 +17,9 @@
 </section>
 <% @podcast_facade.episodes.each do |episode| %>
   <section class ="episodes">
-    <p class="title"><%= episode.title %></p>
-    <p class="description"><%= episode.description %></p>
+    <p class="title"><%= strip_tags(episode.title) %></p>
+    <p class="description"><%= strip_tags(episode.description) %></p>
     <audio src= <%= episode.audio %> controls> </audio>
-    <%= episode.audio_length_sec %>
     <p>Released On: <%= episode.pub_date %></p>
   </section>
 <% end %>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -17,8 +17,10 @@
 </section>
 <% @podcast_facade.episodes.each do |episode| %>
   <section class ="episodes">
-    <p class="name"><%= episode.name %></p>
+    <p class="title"><%= episode.title %></p>
     <p class="description"><%= episode.description %></p>
     <audio src= <%= episode.audio %> controls> </audio>
+    <%= episode.audio_length_sec %>
+    <p>Released On: <%= episode.pub_date %></p>
   </section>
 <% end %>

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     facebook { Faker::Hacker.noun  }
     description {Faker::Movies::HitchhikersGuideToTheGalaxy.marvin_quote }
     adult_content { false }
-    spotify_uri { Faker::Internet.domain_name }
+    spotify_uri { "24a970fdda68488abe659cfe15ae974c" }
     photo { Faker::Placeholdit.image }
     active { false }
     user

--- a/spec/features/podcasts/episode_spec.rb
+++ b/spec/features/podcasts/episode_spec.rb
@@ -8,10 +8,11 @@ describe "When I visit the podcast show page" do
       visit "/podcasts/#{podcast.id}"
 
       within(first('.episodes')) do
-        name = find(".name").text
+        name = find(".title").text
         expect(name).not_to be_empty
       end
     end
+
     it "see episodes description" do
       podcast = create(:podcast)
       visit "/podcasts/#{podcast.id}"
@@ -20,11 +21,6 @@ describe "When I visit the podcast show page" do
         description = find(".description").text
         expect(description).not_to be_empty
       end
-
-    end
-    xit "I can play a full episode" do
-
     end
   end
-
 end

--- a/spec/features/user/podcast_application_spec.rb
+++ b/spec/features/user/podcast_application_spec.rb
@@ -4,9 +4,9 @@ describe 'As a registered user' do
   describe 'When I visit my dashboard' do
     it 'I can apply to submit a podcast' do
       user = create(:user)
-      # create(:tag, name: 'Interviews')
-      # create(:tag, name: 'Music')
-      # create(:tag, name: 'Software')
+      create(:tag, name: 'News')
+      create(:tag, name: 'True Crime')
+      create(:tag, name: 'Politics')
 
       # This needs to be restored once we have the user dashboard/session controller set up.
       #
@@ -23,9 +23,9 @@ describe 'As a registered user' do
 
       fill_in 'podcast[name]', with: 'Dissect'
       page.select 'Denver', from: 'podcast[location]'
-      check 'Interviews'
-      check 'Music'
-      check 'Software'
+      check 'News'
+      check 'True Crime'
+      check 'Politics'
       fill_in 'podcast[twitter]', with: 'www.twitter.com/test'
       fill_in 'podcast[patreon]', with: 'www.patreon.com/test'
       fill_in 'podcast[instagram]', with: 'www.instagram.com/test'


### PR DESCRIPTION
- Adds connection to microservice live on heroku
- Updates podcast factory to use a valid listennotes podcast id (saved as spotify uri)
- Updates podcast facade and podcast show page to reflect changes to api 
- Uses strip_tags to remove html tags from podcast episode descriptions 
