### PR TITLE
fix database migration

### DIFF
--- a/db/migrate/20200722005412_create_podcasts.rb
+++ b/db/migrate/20200722005412_create_podcasts.rb
@@ -9,7 +9,7 @@ class CreatePodcasts < ActiveRecord::Migration[6.0]
       t.string :facebook
       t.string :description
       t.boolean :adult_content
-      t.string :podcast_uri
+      t.string :spotify_uri
       t.string :photo
       t.references :user, foreign_key: true
       t.boolean :active, default: false

--- a/db/migrate/20200729201621_remove_spotify_uri_from_podcasts.rb
+++ b/db/migrate/20200729201621_remove_spotify_uri_from_podcasts.rb
@@ -1,5 +1,5 @@
 class RemoveSpotifyUriFromPodcasts < ActiveRecord::Migration[6.0]
   def change
-    remove_column :podcasts, :podcast_uri, :string
+    remove_column :podcasts, :spotify_uri, :string
   end
 end


### PR DESCRIPTION
The change in the  earlier migrations was causing errors on my end - updating the old migration causes errors as all of our local databases think that "spotify_uri" should exist. "spotify_uri" is still changed to "podcast_uri" but I just changed the old migration back. 